### PR TITLE
Check for current zoom in onCreated listener

### DIFF
--- a/background.js
+++ b/background.js
@@ -32,7 +32,7 @@ browser.storage.onChanged.addListener((newSettings) => {
 });
 
 browser.tabs.onCreated.addListener((tab) => {
-  browser.tabs.setZoom(tab.id, defaultZoom);
+  setZoom(tab.id, {status:1}, tab);         
 });
 
 browser.tabs.onUpdated.addListener(setZoom);


### PR DESCRIPTION
Because onCreated listener always sets zoom to default, the extension fails to respect zoom settings for the home page. Hence issue #5 . Here I change it to use the custom setZoom function instead. Perhaps there's a better solution.