### PR TITLE
Bugfixes, improve reader mode and ctrl+0

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,4 @@
-let defaultZoom = 1;
+let defaultZoom = 1.2;
 
 let gettingDefaultZoom = browser.storage.local.get("defaultZoom");
 gettingDefaultZoom.then((storage) => {
@@ -16,23 +16,29 @@ gettingDefaultZoom.then((storage) => {
   }
 });
 
-function setZoom(tabId, changeInfo, tab) {
-  if (changeInfo.status) {
-    let gettingZoom = browser.tabs.getZoom(tabId);
-    gettingZoom.then((currentZoom) => {
-      if (defaultZoom != 1 && currentZoom == 1) {
-        browser.tabs.setZoom(tabId, defaultZoom);
-      }
-    });
-  }
+function setZoom(tabId) {
+  let gettingZoom = browser.tabs.getZoom(tabId);
+  gettingZoom.then((currentZoom) => {
+    if (defaultZoom != 1 && currentZoom == 1) {
+      browser.tabs.setZoom(tabId, defaultZoom);
+    }
+  });
 }
 
 browser.storage.onChanged.addListener((newSettings) => {
   defaultZoom = parseFloat(newSettings.defaultZoom.newValue) / 100;
 });
 
-browser.tabs.onCreated.addListener((tab) => {
-  browser.tabs.setZoom(tab.id, defaultZoom);
-});
-
-browser.tabs.onUpdated.addListener(setZoom);
+browser.tabs.onCreated.addListener(
+  (tab) => { setZoom(tab.id); }
+)
+browser.tabs.onUpdated.addListener(
+  (tabId, changeInfo, tab) => {
+    if (changeInfo.status) setZoom(tabId);
+  }
+)
+browser.tabs.onZoomChange.addListener(
+  (info) => {
+    if(info.newZoomFactor == 1) setZoom(info.tabId);
+  }
+)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Default Zoom",
   "short_name": "Default Zoom",
-  "version": "1.1.2",
+  "version": "1.2",
   "description": "Set default zoom level for Firefox.",
   "author": "Jamie Nguyen",
   "homepage_url": "https://github.com/jamielinux/default-zoom",


### PR DESCRIPTION
This PR contains 2 things:
1) Bugfix: In onCreated, only set zoom to default if it's 1.
2) Reset zoom to default every time it's changed to 1.
- This fixes some glitches with reader mode and allows ctrl+0 to sent to default zoom
- To be able to set zoom to 1 manually, the user can edit toolkit.zoomManager.zoomValues and change the 1 to 0.99 or 1.01.

You shouldn't merge both this and #8, I'm putting all my changes in one PR because I simplified the code a bit as well.

I won't close #8 in case you don't like the additional changes and want only the bugfix.